### PR TITLE
Fix bug where `controller.text` is not properly updated in PlacesAutocompleteField

### DIFF
--- a/lib/src/places_autocomplete_field.dart
+++ b/lib/src/places_autocomplete_field.dart
@@ -149,6 +149,9 @@ class _LocationAutocompleteFieldState extends State<PlacesAutocompleteField> {
   @override
   void didUpdateWidget(PlacesAutocompleteField oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (widget.controller != null) {
+      widget.controller.text = oldWidget.controller.text;
+    }
     if (widget.controller == null && oldWidget.controller != null)
       _controller = TextEditingController.fromValue(oldWidget.controller.value);
     else if (widget.controller != null && oldWidget.controller == null)


### PR DESCRIPTION
…ield's text value cannot be accessed by client.)

Hello there ! I am a big fan of Flutter. Love you all !!! This is my first time trying to contribute to open-source. 
I found that when I passed in a controller into PlacesAutoCompleteField, I couldn't access the field's text later. After quite some debugging , I found that we were not updating the text field of the newWidget (which I believe is a deep copy ?).  When I updated it in 
`didUpdateWidget`, the problem seems to have been fixed. 

The code to reproduce big is as follows. When I print` _controller.text`, it should print the selected address, but it doesn't.  

```
import 'package:flutter/material.dart';
import 'package:flutter_google_places/flutter_google_places.dart';

class AddEventScreen extends StatefulWidget {
  AddEventState createState() {
    return AddEventState();
  }
}

class AddEventState extends State<AddEventScreen> {
  final _formKey = GlobalKey<FormState>();

  Widget build(BuildContext context) {
    final _controller = new TextEditingController(text: "");

    return Scaffold(
      appBar: AppBar(
        title: Text('Make Event'),
      ),
      body: Form(
          key: _formKey,
          child: Column(
            children: <Widget>[
              PlacesAutocompleteField(
                apiKey: "AIzaSyDYtG5xhm17OtZbEi1PJMLuRctVn43xvgs",
                controller: _controller,
              ),
              Padding(
                padding: const EdgeInsets.symmetric(vertical: 16.0),
                child: RaisedButton(
                  onPressed: () async {
                    print(_controller.text);
                  },
                  child: Text('Submit'),
                ),
              ),
            ],
          )
      ),
    );
  }
}
```